### PR TITLE
feat: Add dual authentication support for TypeScript Workload Identity

### DIFF
--- a/workload-identity-with-aws-ecs-tasks/docker/typescript/.gitignore
+++ b/workload-identity-with-aws-ecs-tasks/docker/typescript/.gitignore
@@ -1,1 +1,2 @@
 dist/
+.tsimp/


### PR DESCRIPTION
## Summary
- Implement automatic environment detection to choose between AWS Workload Identity and gcloud auth
- Add support for local development using gcloud authentication
- Update .gitignore to exclude .tsimp/ directory

## Details
This PR enhances the TypeScript implementation to support dual authentication modes:

1. **AWS Environment (ECS/Fargate)**: Uses Workload Identity Federation to authenticate with Google Cloud
2. **Local Environment**: Uses gcloud auth credentials for development

The code automatically detects the environment by checking for ECS-specific environment variables and chooses the appropriate authentication method.

### Changes Made
- Modified `index.ts` to add environment detection logic
- Added `authenticateWithGcloud()` function for local authentication
- Added `isRunningOnAWS()` helper function
- Updated cell update messages to indicate the environment
- Added `.tsimp/` to .gitignore

## Test Results
✅ Successfully tested on AWS Fargate - authenticated with Workload Identity
✅ Successfully tested locally - authenticated with gcloud auth
✅ Both environments can read and update Google Spreadsheets

🤖 Generated with [Claude Code](https://claude.ai/code)