### PR TITLE
fix: Remove mizzy-specific project ID and add validation

### DIFF
--- a/workload-identity-with-aws-ecs-tasks/docker/typescript/src/index.ts
+++ b/workload-identity-with-aws-ecs-tasks/docker/typescript/src/index.ts
@@ -38,13 +38,13 @@ class AwsSupplier implements AwsSecurityCredentialsSupplier {
 
 async function authenticateWithWorkloadIdentity() {
     const projectNumber = process.env.GCP_PROJECT_NUMBER;
-    const projectId = process.env.GCP_PROJECT_ID || 'mizzy-270104';
+    const projectId = process.env.GCP_PROJECT_ID;
     const poolId = process.env.WORKLOAD_IDENTITY_POOL_ID;
     const providerId = process.env.WORKLOAD_IDENTITY_PROVIDER_ID;
     const serviceAccountEmail = process.env.SERVICE_ACCOUNT_EMAIL;
     const region = process.env.AWS_REGION || 'ap-northeast-1';
 
-    if (!projectNumber || !poolId || !providerId || !serviceAccountEmail) {
+    if (!projectNumber || !projectId || !poolId || !providerId || !serviceAccountEmail) {
         throw new Error('Missing required environment variables for Workload Identity');
     }
 


### PR DESCRIPTION
## Summary
- Remove hardcoded default project ID 'mizzy-270104' from TypeScript implementation
- Add projectId validation to ensure all required environment variables are present
- Make GCP_PROJECT_ID a required environment variable with no default fallback

## Test plan
- [ ] Verify that the application throws an error when GCP_PROJECT_ID is not set
- [ ] Verify that the application works correctly when all required environment variables are provided
- [ ] Run the application both locally and on AWS ECS to ensure dual authentication still works

🤖 Generated with [Claude Code](https://claude.ai/code)