### PR TITLE
refactor: Remove spreadsheet update functionality

### DIFF
--- a/workload-identity-with-aws-ecs-tasks/docker/typescript/src/index.ts
+++ b/workload-identity-with-aws-ecs-tasks/docker/typescript/src/index.ts
@@ -137,23 +137,6 @@ async function accessSpreadsheet(spreadsheetId: string, range: string) {
         console.log('Spreadsheet data:');
         console.log(JSON.stringify(response.data.values, null, 2));
 
-        // Example: Update a cell
-        const updateRange = 'A1';
-        const updateMessage = await isRunningOnAWS() 
-            ? `Updated from AWS Fargate at ${new Date().toISOString()}`
-            : `Updated from local environment at ${new Date().toISOString()}`;
-            
-        const updateResponse = await sheets.spreadsheets.values.update({
-            spreadsheetId,
-            range: updateRange,
-            valueInputOption: 'RAW',
-            requestBody: {
-                values: [[updateMessage]],
-            },
-        });
-
-        console.log(`Updated cell ${updateRange}: ${updateResponse.data.updatedCells} cells updated`);
-
     } catch (error: any) {
         console.error('Error accessing spreadsheet:', error);
         if (error.response) {


### PR DESCRIPTION
## Summary
- Remove the update operation from accessSpreadsheet function
- Keep only the read functionality for accessing Google Sheets
- Simplify the code to focus on reading spreadsheet data

## Test plan
- [ ] Verify that the application still reads spreadsheet data correctly
- [ ] Ensure no update operations are performed on the spreadsheet
- [ ] Test both local (gcloud auth) and AWS (Workload Identity) authentication methods

🤖 Generated with [Claude Code](https://claude.ai/code)