### PR TITLE
Fix missing GCP_PROJECT_ID environment variable

### DIFF
--- a/workload-identity-with-aws-ecs-tasks/ecspresso/ecs-task-def.jsonnet
+++ b/workload-identity-with-aws-ecs-tasks/ecspresso/ecs-task-def.jsonnet
@@ -24,6 +24,10 @@ local tfstate = std.native('tfstate');
           value: '376742608836',
         },
         {
+          name: 'GCP_PROJECT_ID',
+          value: 'service-account-466904',
+        },
+        {
           name: 'WORKLOAD_IDENTITY_POOL_ID',
           value: 'mizzy-pool',
         },


### PR DESCRIPTION
## Summary
Fix the error "Missing required environment variables for Workload Identity" by adding the missing `GCP_PROJECT_ID` environment variable to the ECS task definition.

## Problem
The TypeScript application checks for several environment variables including `GCP_PROJECT_ID` in the `authenticateWithWorkloadIdentity()` function, but this variable was not provided in the ECS task definition, causing the application to fail.

## Solution
Added `GCP_PROJECT_ID` environment variable with value `service-account-466904` to the ecspresso task definition. This value matches the project configuration in `terraform/providers.tf`.

## Test plan
- [ ] Deploy the updated task definition with ecspresso
- [ ] Verify the container starts successfully without the "Missing required environment variables" error
- [ ] Confirm the application can authenticate with Google Cloud using Workload Identity

🤖 Generated with [Claude Code](https://claude.ai/code)