### PR TITLE
fix: Set GOOGLE_CLOUD_QUOTA_PROJECT for local gcloud authentication

### DIFF
--- a/workload-identity-with-aws-ecs-tasks/docker/typescript/src/index.ts
+++ b/workload-identity-with-aws-ecs-tasks/docker/typescript/src/index.ts
@@ -121,9 +121,6 @@ async function authenticateWithGcloud() {
   // Create GoogleAuth instance that will use Application Default Credentials
   const auth = new GoogleAuth({
     scopes: ["https://www.googleapis.com/auth/spreadsheets"],
-    clientOptions: {
-      quotaProjectId: projectId,
-    },
   });
 
   try {

--- a/workload-identity-with-aws-ecs-tasks/docker/typescript/src/index.ts
+++ b/workload-identity-with-aws-ecs-tasks/docker/typescript/src/index.ts
@@ -108,6 +108,16 @@ async function authenticateWithGcloud() {
 
   const projectId = process.env.GCP_PROJECT_ID;
 
+  if (!projectId) {
+    throw new Error(
+      "GCP_PROJECT_ID environment variable is required for quota project",
+    );
+  }
+
+  // Set the quota project environment variable for Google Cloud SDK
+  process.env.GOOGLE_CLOUD_QUOTA_PROJECT = projectId;
+  console.log(`  Setting GOOGLE_CLOUD_QUOTA_PROJECT: ${projectId}`);
+
   // Create GoogleAuth instance that will use Application Default Credentials
   const auth = new GoogleAuth({
     scopes: ["https://www.googleapis.com/auth/spreadsheets"],


### PR DESCRIPTION
## Summary
- Fixed Google Sheets API quota project error when using local Application Default Credentials
- Added `GOOGLE_CLOUD_QUOTA_PROJECT` environment variable setting in `authenticateWithGcloud` function
- Added validation to ensure `GCP_PROJECT_ID` is set before using it

## Problem
When running locally with gcloud authentication, the Google Sheets API returns an error:
```
Your application is authenticating by using local Application Default Credentials. 
The sheets.googleapis.com API requires a quota project, which is not set by default.
```

## Solution
Set the `GOOGLE_CLOUD_QUOTA_PROJECT` environment variable programmatically before creating the GoogleAuth instance. This ensures the quota project is properly configured for API requests.

## Test plan
- [x] Run `yarn dev` locally with gcloud authentication
- [x] Verify that the Google Sheets API can be accessed without quota project errors
- [x] Confirm the code works correctly with the environment variable set

🤖 Generated with [Claude Code](https://claude.ai/code)