### PR TITLE
Remove unnecessary resourcemanager.projects.get permission from iam-for-iam role

### DIFF
--- a/google-project-service/iam-for-iam/main.tf
+++ b/google-project-service/iam-for-iam/main.tf
@@ -33,9 +33,6 @@ resource "google_project_iam_custom_role" "iam_manager" {
     # Service account IAM policy (needed for impersonation setup)
     "iam.serviceAccounts.getIamPolicy",
     "iam.serviceAccounts.setIamPolicy",
-    
-    # Project metadata (needed by Terraform provider)
-    "resourcemanager.projects.get",
   ]
 }
 


### PR DESCRIPTION
## Summary
- Removed `resourcemanager.projects.get` permission from the iam-for-iam custom role
- Testing confirmed this permission is not needed for IAM resource management

## Test plan
- [x] Run `terraform plan` in iam-for-iam directory without the permission - works correctly
- [x] Run `terraform apply` in iam-for-iam directory without the permission - resources created successfully  
- [x] Run `terraform plan` in iam directory with deploy-iam impersonation - works correctly even when iam-for-iam role lacks this permission

🤖 Generated with [Claude Code](https://claude.ai/code)