### PR TITLE
feat: Add Aurora PostgreSQL Blue/Green deployment configuration and procedures

### DIFF
--- a/aurora-blue-green-deployment/.terraform.lock.hcl
+++ b/aurora-blue-green-deployment/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.8.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:HDnB+foDh9HJd81T+ddn2tC0DXonSUwovBdvuKe9dZs=",
+    "zh:04781915164a85316d2f659383bb4a2c26ce258efdd63b10ebf5dc741b13d3a4",
+    "zh:050eba0f1d40b6a2542206742fbf8697b139e045120e50b59fa090eb1babb46d",
+    "zh:0590b7ba32f211142fc1acc1350560ce47faa287aeec697b577c9fe10e0efcab",
+    "zh:279943444a858c38976b30248bdcf968ff4b536b9cd8054e7475b8e493c67a16",
+    "zh:46c556c8753d31fdb98123ba3437e6eded07d7671c2cbfc127b2c315f82c0899",
+    "zh:5f6943dfd9e44458b6b915a64f5e103b0e7cff98bf804bb95b8eedaa9c6cc786",
+    "zh:6456d583155ce05028517425a5b5057a05978a89f90df29f37c5c2295e37f605",
+    "zh:83fc4712f0a972b13be71e4323982f55687fb431e1657c91854d3ec8ff846dfb",
+    "zh:921d2761e8474eb12cde03e57dba127021edff8423183241528514351519f721",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f7e13279fcb9ca3e775cbda837735d6868c2fc966e7c23aa27607838ce06c11",
+    "zh:a21075ba6cf6345ed2b28c64bd52af3871d3957f8ca13dbce488975c8b496cbc",
+    "zh:c2e05b36d5d1eb106eb1e763fca9b9ea9e0e5f9900c773b5a80678b66229cfc1",
+    "zh:f340a9a4b67d3f63f36e68ba73145900b7c5cb774d7716aef0600e853fad910e",
+    "zh:f5ce5af7e58f7b3a06b902efb953b64895e5c70c203fc9cdeeb75db240abba31",
+  ]
+}

--- a/aurora-blue-green-deployment/aurora-bg-rollback-procedure.md
+++ b/aurora-blue-green-deployment/aurora-bg-rollback-procedure.md
@@ -1,0 +1,261 @@
+# Aurora PostgreSQL ブルー/グリーン デプロイメント ロールバック手順書
+
+## 概要
+ブルー/グリーン デプロイメントによるスイッチオーバー後に問題が発生した場合のロールバック手順を説明します。
+
+## ロールバック方法の選択
+
+以下の2つの方法があります：
+- **方法A**: 簡易ロールバック（データ巻き戻りが許容される場合）
+- **方法B**: 完全なロールバック（データを保持する場合）
+
+---
+
+## 方法A: 簡易ロールバック（データ巻き戻りが許容される場合）
+
+**注意**: この方法では、スイッチオーバー後に書き込まれたデータはすべて失われます。旧環境（-old1）が削除されていない場合のみ使用可能です。
+
+### 1. 現在のクラスター名を確認
+```bash
+aws-vault exec mizzy -- aws rds describe-db-clusters \
+  --region ap-northeast-1 \
+  --query 'DBClusters[?contains(DBClusterIdentifier, `aurora-bg-aurora-cluster`)].[DBClusterIdentifier,EngineVersion,Status]' \
+  --output table
+```
+
+### 2. 旧環境へ名前を入れ替え
+```bash
+# 現在のクラスター（15.10）を一時的な名前に変更
+aws-vault exec mizzy -- aws rds modify-db-cluster \
+  --db-cluster-identifier aurora-bg-aurora-cluster \
+  --new-db-cluster-identifier aurora-bg-aurora-cluster-temp \
+  --apply-immediately \
+  --region ap-northeast-1 >/dev/null
+
+echo "現在のクラスターを一時名に変更中..."
+
+# 旧環境（15.6）を元の名前に戻す
+aws-vault exec mizzy -- aws rds modify-db-cluster \
+  --db-cluster-identifier aurora-bg-aurora-cluster-old1 \
+  --new-db-cluster-identifier aurora-bg-aurora-cluster \
+  --apply-immediately \
+  --region ap-northeast-1 >/dev/null
+
+echo "旧環境を元の名前に戻しました"
+```
+
+### 3. インスタンス名も同様に入れ替え
+```bash
+# 現在のインスタンスを一時名に変更
+for i in 1 2; do
+  aws-vault exec mizzy -- aws rds modify-db-instance \
+    --db-instance-identifier aurora-bg-aurora-instance-$i \
+    --new-db-instance-identifier aurora-bg-aurora-instance-$i-temp \
+    --apply-immediately \
+    --region ap-northeast-1 >/dev/null
+  echo "aurora-bg-aurora-instance-$i を一時名に変更中..."
+done
+
+# 旧環境のインスタンスを元の名前に戻す
+for i in 1 2; do
+  aws-vault exec mizzy -- aws rds modify-db-instance \
+    --db-instance-identifier aurora-bg-aurora-instance-$i-old1 \
+    --new-db-instance-identifier aurora-bg-aurora-instance-$i \
+    --apply-immediately \
+    --region ap-northeast-1 >/dev/null
+  echo "aurora-bg-aurora-instance-$i-old1 を元の名前に戻しています..."
+done
+```
+
+### 4. 変更の完了を待機
+```bash
+for i in 1 2; do
+  aws-vault exec mizzy -- aws rds wait db-instance-available \
+    --db-instance-identifier aurora-bg-aurora-instance-$i \
+    --region ap-northeast-1
+  echo "aurora-bg-aurora-instance-$i が利用可能になりました"
+done
+
+echo "ロールバックが完了しました（バージョン15.6に戻りました）"
+```
+
+**重要**: この方法ではエンドポイントは変更されませんが、スイッチオーバー後のデータはすべて失われます。
+
+---
+
+## 方法B: 完全なロールバック（データを保持する場合）
+
+データの巻き戻しが許容されない場合は、スナップショットからの復元が必要です。
+
+### 1. データベースへのアクセスを停止
+
+クラスターを停止してアクセスを遮断：
+```bash
+aws-vault exec mizzy -- aws rds stop-db-cluster \
+  --db-cluster-identifier aurora-bg-aurora-cluster \
+  --region ap-northeast-1 >/dev/null
+
+echo "クラスターを停止中..."
+
+aws-vault exec mizzy -- aws rds wait db-cluster-stopped \
+  --db-cluster-identifier aurora-bg-aurora-cluster \
+  --region ap-northeast-1
+
+echo "クラスターが停止しました"
+```
+
+### 2. 現在の状態のスナップショットを作成
+
+```bash
+SNAPSHOT_ID="aurora-bg-aurora-cluster-rollback-$(date +%Y%m%d-%H%M%S)"
+
+aws-vault exec mizzy -- aws rds create-db-cluster-snapshot \
+  --db-cluster-snapshot-identifier $SNAPSHOT_ID \
+  --db-cluster-identifier aurora-bg-aurora-cluster \
+  --region ap-northeast-1 >/dev/null
+
+echo "スナップショット $SNAPSHOT_ID を作成中..."
+
+aws-vault exec mizzy -- aws rds wait db-cluster-snapshot-completed \
+  --db-cluster-snapshot-identifier $SNAPSHOT_ID \
+  --region ap-northeast-1
+
+echo "スナップショットの作成が完了しました"
+```
+
+### 3. スイッチオーバー前のスナップショットを確認
+
+```bash
+aws-vault exec mizzy -- aws rds describe-db-cluster-snapshots \
+  --db-cluster-identifier aurora-bg-aurora-cluster \
+  --region ap-northeast-1 \
+  --query 'DBClusterSnapshots[*].[DBClusterSnapshotIdentifier,SnapshotCreateTime,Status]' \
+  --output table
+```
+
+### 4. スナップショットからの復元（実際のロールバック）
+
+#### 4.1 既存クラスターのインスタンスを削除
+```bash
+aws-vault exec mizzy -- aws rds describe-db-instances \
+  --filters "Name=db-cluster-id,Values=aurora-bg-aurora-cluster" \
+  --region ap-northeast-1 \
+  --query 'DBInstances[*].DBInstanceIdentifier' \
+  --output text | tr '\t' '\n' | while read instance_id; do
+  aws-vault exec mizzy -- aws rds delete-db-instance \
+    --db-instance-identifier "$instance_id" \
+    --skip-final-snapshot \
+    --region ap-northeast-1 >/dev/null
+  echo "$instance_id を削除中..."
+done
+```
+
+インスタンス削除完了まで待機：
+```bash
+aws-vault exec mizzy -- aws rds describe-db-instances \
+  --filters "Name=db-cluster-id,Values=aurora-bg-aurora-cluster" \
+  --region ap-northeast-1 \
+  --query 'DBInstances[*].DBInstanceIdentifier' \
+  --output text | tr '\t' '\n' | while read instance_id; do
+  echo "$instance_id の削除完了を待機中..."
+  aws-vault exec mizzy -- aws rds wait db-instance-deleted \
+    --db-instance-identifier "$instance_id" \
+    --region ap-northeast-1
+  echo "$instance_id の削除が完了しました"
+done
+```
+
+#### 4.2 既存クラスターを削除
+```bash
+aws-vault exec mizzy -- aws rds delete-db-cluster \
+  --db-cluster-identifier aurora-bg-aurora-cluster \
+  --skip-final-snapshot \
+  --region ap-northeast-1 >/dev/null
+echo "aurora-bg-aurora-cluster を削除中..."
+
+aws-vault exec mizzy -- aws rds wait db-cluster-deleted \
+  --db-cluster-identifier aurora-bg-aurora-cluster \
+  --region ap-northeast-1
+echo "aurora-bg-aurora-cluster の削除が完了しました"
+```
+
+#### 4.3 スナップショットから同じ名前で復元
+```bash
+RESTORE_SNAPSHOT_ID="<復元したいスナップショットID>"
+
+aws-vault exec mizzy -- aws rds restore-db-cluster-from-snapshot \
+  --db-cluster-identifier aurora-bg-aurora-cluster \
+  --snapshot-identifier $RESTORE_SNAPSHOT_ID \
+  --engine aurora-postgresql \
+  --db-subnet-group-name aurora-bg-aurora-subnet-group \
+  --db-cluster-parameter-group-name aurora-bg-aurora-pg15-cluster-params \
+  --vpc-security-group-ids $(aws-vault exec mizzy -- aws ec2 describe-security-groups \
+    --filters "Name=group-name,Values=aurora-bg-aurora-sg" \
+    --region ap-northeast-1 \
+    --query 'SecurityGroups[0].GroupId' \
+    --output text) \
+  --region ap-northeast-1 >/dev/null
+
+echo "クラスターを復元中..."
+
+aws-vault exec mizzy -- aws rds wait db-cluster-available \
+  --db-cluster-identifier aurora-bg-aurora-cluster \
+  --region ap-northeast-1
+
+echo "クラスターの復元が完了しました"
+```
+
+#### 4.4 インスタンスを作成
+```bash
+for i in 1 2; do
+  aws-vault exec mizzy -- aws rds create-db-instance \
+    --db-instance-identifier aurora-bg-aurora-instance-$i \
+    --db-cluster-identifier aurora-bg-aurora-cluster \
+    --db-instance-class db.t4g.medium \
+    --engine aurora-postgresql \
+    --db-parameter-group-name aurora-bg-aurora-pg15-params \
+    --region ap-northeast-1 >/dev/null
+  echo "aurora-bg-aurora-instance-$i を作成中..."
+done
+
+for i in 1 2; do
+  aws-vault exec mizzy -- aws rds wait db-instance-available \
+    --db-instance-identifier aurora-bg-aurora-instance-$i \
+    --region ap-northeast-1
+  echo "aurora-bg-aurora-instance-$i の作成が完了しました"
+done
+```
+
+#### 4.5 新しいエンドポイントを確認
+**重要**: 同じクラスター名で復元しても、エンドポイントのドメイン名は変更されます。
+
+```bash
+aws-vault exec mizzy -- aws rds describe-db-clusters \
+  --db-cluster-identifier aurora-bg-aurora-cluster \
+  --region ap-northeast-1 \
+  --query 'DBClusters[0].[Endpoint,ReaderEndpoint]' \
+  --output table
+```
+
+### エンドポイントを変更したくない場合の対策
+
+以下のいずれかの方法を事前に実装しておくことを推奨します：
+
+1. **Route 53 CNAMEレコードを使用**（推奨）
+   - 独自ドメインのCNAMEレコードを作成し、Auroraエンドポイントを指すように設定
+   - アプリケーションは独自ドメイン名で接続
+   - ロールバック時はCNAMEレコードの向き先を更新するだけ
+
+2. **別名で復元して、ブルー/グリーン デプロイメントで切り替え**
+   - 別のクラスター名で復元（例: aurora-bg-aurora-cluster-rollback）
+   - 新たにブルー/グリーン デプロイメントを作成してスイッチオーバー
+   - ただし、この方法でもエンドポイントは変更される可能性があります
+
+---
+
+## 注意事項
+
+1. **データの整合性**: 方法Aではデータが失われるため、必ず事前に影響を確認してください
+2. **エンドポイント**: 方法Bではエンドポイントが変更されるため、アプリケーション側の設定変更が必要になる場合があります
+3. **スナップショット**: ロールバック前に必ず現在の状態のスナップショットを取得してください
+4. **テスト**: 本番環境でのロールバック前に、可能であればテスト環境で手順を確認してください

--- a/aurora-blue-green-deployment/aurora-bg-upgrade-procedure.md
+++ b/aurora-blue-green-deployment/aurora-bg-upgrade-procedure.md
@@ -1,7 +1,7 @@
 # Aurora PostgreSQL ブルー/グリーン デプロイメントによるバージョンアップ手順書
 
 ## 概要
-本手順書では、Aurora PostgreSQL クラスターを 15.6 から 15.10 へ、ブルー/グリーン デプロイメントを使用して安全にアップグレードする手順を説明します。
+本手順書では、Aurora PostgreSQL クラスターを 15.6 から 15.10 へ、ブルー/グリーン デプロイメントを使用してアップグレードする手順を説明します。
 
 ## 前提条件
 - AWS CLI がインストールされていること
@@ -20,7 +20,7 @@
 
 ### 1. 事前確認
 
-#### 1.1 現在のクラスター情報を確認
+#### 1.1 現在のクラスターのバージョンとステータスを確認
 ```bash
 aws-vault exec mizzy -- aws rds describe-db-clusters \
   --db-cluster-identifier aurora-bg-aurora-cluster \
@@ -29,7 +29,23 @@ aws-vault exec mizzy -- aws rds describe-db-clusters \
   --output table
 ```
 
-#### 1.2 現在のインスタンス情報を確認
+**期待される出力例**:
+```
+-----------------------------------------
+|         DescribeDBClusters            |
++---------------------------------------+
+|  aurora-bg-aurora-cluster             |
+|  15.6                                 |
+|  available                            |
++---------------------------------------+
+```
+
+**確認事項**:
+- [ ] クラスター識別子が `aurora-bg-aurora-cluster` である
+- [ ] 現在のバージョンが `15.6` である
+- [ ] ステータスが `available` である
+
+#### 1.2 現在のインスタンスのバージョンとステータスを確認
 ```bash
 aws-vault exec mizzy -- aws rds describe-db-instances \
   --filters "Name=db-cluster-id,Values=aurora-bg-aurora-cluster" \
@@ -38,7 +54,22 @@ aws-vault exec mizzy -- aws rds describe-db-instances \
   --output table
 ```
 
-#### 1.3 ターゲットバージョン（15.10）が利用可能であることを確認
+**期待される出力例**（2インスタンスの場合）:
+```
+-------------------------------------------------------
+|              DescribeDBInstances                    |
++------------------------------+---------+------------+
+|  aurora-bg-aurora-instance-1 |  15.6   |  available |
+|  aurora-bg-aurora-instance-2 |  15.6   |  available |
++------------------------------+---------+------------+
+```
+
+**確認事項**:
+- [ ] すべてのインスタンスが表示されている
+- [ ] すべてのインスタンスのバージョンが `15.6` である
+- [ ] すべてのインスタンスのステータスが `available` である
+
+#### 1.3 ターゲットバージョン（15.10）の利用可能性を確認
 ```bash
 aws-vault exec mizzy -- aws rds describe-db-engine-versions \
   --engine aurora-postgresql \
@@ -48,9 +79,22 @@ aws-vault exec mizzy -- aws rds describe-db-engine-versions \
   --output table
 ```
 
-バージョンが表示されれば、15.10へのアップグレードが可能です。
+**期待される出力例**:
+```
+----------------------------------------------------
+|          DescribeDBEngineVersions                |
++--------------------------------------------------+
+|  aurora-postgresql                              |
+|  15.10                                          |
+|  aurora-postgresql15                            |
++--------------------------------------------------+
+```
 
-### 2. 論理レプリケーションの有効化（必要な場合）
+**確認事項**:
+- [ ] バージョン `15.10` が表示されている
+- [ ] パラメータグループファミリーが `aurora-postgresql15` である
+
+### 2. 論理レプリケーションの有効化
 
 Terraformで`rds.logical_replication = 1`を設定した後、インスタンスの再起動をしていない場合、設定を反映させるために再起動が必要です。
 
@@ -94,27 +138,37 @@ echo "全インスタンスの再起動が完了しました"
 
 **期待される出力例**（2インスタンスの場合）:
 ```
+aurora-bg-aurora-instance-1 の再起動完了を待機中...
 aurora-bg-aurora-instance-1 の再起動が完了しました
+aurora-bg-aurora-instance-2 の再起動完了を待機中...
 aurora-bg-aurora-instance-2 の再起動が完了しました
 全インスタンスの再起動が完了しました
 ```
 
+**確認事項**:
+- [ ] すべてのインスタンスの再起動が完了した
+
 ### 3. ブルー/グリーン デプロイメントの作成
 
-#### 3.1 クラスターのARNを取得
+#### 3.1 クラスターARNをシェル変数にセット
+ブルー/グリーン デプロイメント作成に必要なクラスターARNを取得してシェル変数にセットします：
+
 ```bash
 CLUSTER_ARN=$(aws-vault exec mizzy -- aws rds describe-db-clusters \
   --db-cluster-identifier aurora-bg-aurora-cluster \
   --region ap-northeast-1 \
   --query 'DBClusters[0].DBClusterArn' \
   --output text)
-```
 
-```bash
 echo $CLUSTER_ARN
 ```
 
+**確認事項**:
+- [ ] クラスターARNがシェル変数`CLUSTER_ARN`にセットされた
+
 #### 3.2 ブルー/グリーン デプロイメントを作成
+15.10へのアップグレード用のブルー/グリーン デプロイメントを作成して、デプロイメントIDをシェル変数にセットします：
+
 ```bash
 BG_DEPLOYMENT_ID=$(aws-vault exec mizzy -- aws rds create-blue-green-deployment \
   --blue-green-deployment-name aurora-bg-upgrade-15-10 \
@@ -125,13 +179,16 @@ BG_DEPLOYMENT_ID=$(aws-vault exec mizzy -- aws rds create-blue-green-deployment 
   --region ap-northeast-1 \
   --query 'BlueGreenDeployment.BlueGreenDeploymentIdentifier' \
   --output text)
-```
 
-```bash
 echo $BG_DEPLOYMENT_ID
 ```
 
+**確認事項**:
+- [ ] デプロイメントIDがシェル変数`BG_DEPLOYMENT_ID`にセットされた
+
 #### 3.3 デプロイメントのステータスを確認
+作成したブルー/グリーン デプロイメントの初期ステータスを確認します：
+
 ```bash
 aws-vault exec mizzy -- aws rds describe-blue-green-deployments \
   --blue-green-deployment-identifier $BG_DEPLOYMENT_ID \
@@ -153,8 +210,15 @@ aws-vault exec mizzy -- aws rds describe-blue-green-deployments \
 
 `PROVISIONING`はグリーン環境を作成中の状態です。
 
+**確認事項**:
+- [ ] ステータスが `PROVISIONING` である
+
 #### 3.4 デプロイメントが利用可能になるまで待機
-**注意**: グリーン環境の作成には時間がかかります（データベースのサイズやインスタンス数により30分〜1時間以上）。
+
+> [!WARNING]
+> グリーン環境の作成には時間がかかります（データベースのサイズやインスタンス数により30分〜1時間以上）。
+
+ステータスが`AVAILABLE`になるまで定期的にチェックします：
 
 ```bash
 while true; do
@@ -188,9 +252,16 @@ Wed Jan 15 10:45:00 JST 2025: ステータス = AVAILABLE
 ブルー/グリーン デプロイメントが利用可能になりました
 ```
 
+**確認事項**:
+- [ ] ステータスが `AVAILABLE` になった
+
 ### 4. グリーン環境の再起動
 
+グリーン環境作成後のパラメータ適用を確実に行うため、グリーン環境のすべてのインスタンスを再起動します。
+
 #### 4.1 グリーン環境のクラスター識別子を取得
+グリーン環境のクラスターARNから識別子を抽出してシェル変数にセットします：
+
 ```bash
 GREEN_CLUSTER_ARN=$(aws-vault exec mizzy -- aws rds describe-blue-green-deployments \
   --blue-green-deployment-identifier $BG_DEPLOYMENT_ID \
@@ -199,14 +270,15 @@ GREEN_CLUSTER_ARN=$(aws-vault exec mizzy -- aws rds describe-blue-green-deployme
   --output text)
 
 GREEN_CLUSTER_ID=$(echo $GREEN_CLUSTER_ARN | awk -F: '{print $NF}')
-```
 
-```bash
 echo $GREEN_CLUSTER_ID
 ```
 
+**確認事項**:
+- [ ] グリーン環境のクラスター識別子がシェル変数`GREEN_CLUSTER_ID`にセットされた
+
 #### 4.2 グリーン環境のインスタンスを再起動
-アップグレード後のパラメータ適用を確実に行うため、グリーン環境のすべてのインスタンスを再起動します：
+クラスター内のすべてのインスタンスを個別に再起動します：
 
 ```bash
 aws-vault exec mizzy -- aws rds describe-db-instances \
@@ -253,9 +325,12 @@ aurora-bg-aurora-cluster-green-xxxxxx-instance-2 の再起動が完了しまし�
 グリーン環境の全インスタンスの再起動が完了しました
 ```
 
+**確認事項**:
+- [ ] すべてのグリーン環境インスタンスの再起動が完了した
+
 ### 5. グリーン環境の検証（オプション）
 
-グリーン環境のエンドポイントを使用して、アプリケーションの動作確認を行います。
+グリーン環境のエンドポイントを取得して、必要に応じてアプリケーションの動作確認を行います：
 
 ```bash
 GREEN_ENDPOINT=$(aws-vault exec mizzy -- aws rds describe-db-clusters \
@@ -263,16 +338,30 @@ GREEN_ENDPOINT=$(aws-vault exec mizzy -- aws rds describe-db-clusters \
   --region ap-northeast-1 \
   --query 'DBClusters[0].Endpoint' \
   --output text)
-```
 
-```bash
 echo $GREEN_ENDPOINT
 ```
 
 ### 6. スイッチオーバーの実行
 
 #### 6.1 スイッチオーバー前のスナップショット取得
-スイッチオーバー前に、現在のBlue環境（本番環境）のスナップショットを取得します：
+スイッチオーバー前に、現在のブルー環境（本番環境）のスナップショットを取得してバックアップを作成します。
+
+まず、クラスターが利用可能な状態であることを確認：
+```bash
+aws-vault exec mizzy -- aws rds describe-db-clusters \
+  --db-cluster-identifier aurora-bg-aurora-cluster \
+  --region ap-northeast-1 \
+  --query 'DBClusters[0].Status' \
+  --output text
+```
+
+**期待される出力**:
+```
+available
+```
+
+ステータスが`available`であることを確認してから、スナップショットを作成：
 
 ```bash
 SNAPSHOT_ID="aurora-bg-aurora-cluster-before-switchover-$(date +%Y%m%d-%H%M%S)"
@@ -282,22 +371,40 @@ aws-vault exec mizzy -- aws rds create-db-cluster-snapshot \
   --db-cluster-identifier aurora-bg-aurora-cluster \
   --region ap-northeast-1 >/dev/null
 
-echo "スナップショット $SNAPSHOT_ID を作成中..."
-
-aws-vault exec mizzy -- aws rds wait db-cluster-snapshot-completed \
-  --db-cluster-snapshot-identifier $SNAPSHOT_ID \
-  --region ap-northeast-1
-
-echo "スナップショットの作成が完了しました"
+echo "スナップショット $SNAPSHOT_ID の作成を開始しました"
+echo "（クラスターは一時的にbacking-up状態になります）"
 ```
 
 **期待される出力例**:
 ```
-スナップショット aurora-bg-aurora-cluster-before-switchover-20250115-110000 を作成中...
-スナップショットの作成が完了しました
+スナップショット aurora-bg-aurora-cluster-before-switchover-20250115-110000 の作成を開始しました
+（クラスターは一時的にbacking-up状態になります）
 ```
 
+スナップショット作成後、クラスターは一時的に`backing-up`状態になります。`available`状態に戻るまで待機：
+```bash
+echo "ブルー環境のクラスターが利用可能になるまで待機中..."
+echo "（スナップショット作成によりbacking-up状態からavailable状態に戻るのを待っています）"
+aws-vault exec mizzy -- aws rds wait db-cluster-available \
+  --db-cluster-identifier aurora-bg-aurora-cluster \
+  --region ap-northeast-1
+echo "ブルー環境のクラスターが利用可能になりました"
+```
+
+**期待される出力例**:
+```
+ブルー環境のクラスターが利用可能になるまで待機中...
+（スナップショット作成によりbacking-up状態からavailable状態に戻るのを待っています）
+ブルー環境のクラスターが利用可能になりました
+```
+
+**確認事項**:
+- [ ] スナップショットの作成を開始した
+- [ ] クラスターが`available`状態に戻った
+
 #### 6.2 スイッチオーバー前の最終確認
+ブルー/グリーン デプロイメントがスイッチオーバー可能な状態であることを確認します：
+
 ```bash
 aws-vault exec mizzy -- aws rds describe-blue-green-deployments \
   --blue-green-deployment-identifier $BG_DEPLOYMENT_ID \
@@ -320,8 +427,16 @@ aws-vault exec mizzy -- aws rds describe-blue-green-deployments \
 - `AVAILABLE`: スイッチオーバー可能な状態
 - `None`: エラーや警告がない正常な状態
 
+**確認事項**:
+- [ ] ステータスが `AVAILABLE` である
+- [ ] StatusDetailsが `None` である
+
 #### 6.3 スイッチオーバーを実行して完了を待機
-**注意**: スイッチオーバーは通常数分で完了しますが、この間データベースへの接続が一時的に切断されます。
+
+> [!IMPORTANT]
+> スイッチオーバーは通常数分で完了しますが、この間データベースへの接続が一時的に切断されます。
+
+ブルー環境とグリーン環境を切り替え、グリーン環境を新しい本番環境にします：
 
 ```bash
 aws-vault exec mizzy -- aws rds switchover-blue-green-deployment \
@@ -362,9 +477,14 @@ Wed Jan 15 11:02:00 JST 2025: ステータス = SWITCHOVER_COMPLETED
 スイッチオーバーが完了しました
 ```
 
-### 7. アップグレード後の確認と再起動
+**確認事項**:
+- [ ] ステータスが `SWITCHOVER_COMPLETED` になった
 
-#### 7.1 アップグレード後のクラスターバージョンを確認
+### 7. スイッチオーバー後の確認
+
+#### 7.1 スイッチオーバー後のクラスターバージョンを確認
+スイッチオーバー完了後、クラスターが正しくアップグレードされたことを確認します：
+
 ```bash
 aws-vault exec mizzy -- aws rds describe-db-clusters \
   --db-cluster-identifier aurora-bg-aurora-cluster \
@@ -384,9 +504,13 @@ aws-vault exec mizzy -- aws rds describe-db-clusters \
 +-------------------------------------------+
 ```
 
-バージョンが `15.10` にアップグレードされていることを確認します。
+**確認事項**:
+- [ ] バージョンが `15.10` にアップグレードされている
+- [ ] ステータスが `available` である
 
 #### 7.2 インスタンスのバージョンを確認
+すべてのインスタンスもアップグレードされていることを確認します：
+
 ```bash
 aws-vault exec mizzy -- aws rds describe-db-instances \
   --filters "Name=db-cluster-id,Values=aurora-bg-aurora-cluster" \
@@ -405,76 +529,9 @@ aws-vault exec mizzy -- aws rds describe-db-instances \
 +------------------------------+---------+------------+
 ```
 
-すべてのインスタンスが `15.10` にアップグレードされ、`available` 状態であることを確認します。
-
-#### 7.3 インスタンスの再起動
-スイッチオーバー後、パラメータグループの完全な同期のため、すべてのインスタンスを再起動します：
-
-```bash
-aws-vault exec mizzy -- aws rds describe-db-instances \
-  --filters "Name=db-cluster-id,Values=aurora-bg-aurora-cluster" \
-  --region ap-northeast-1 \
-  --query 'DBInstances[*].DBInstanceIdentifier' \
-  --output text | tr '\t' '\n' | while read instance_id; do
-  aws-vault exec mizzy -- aws rds reboot-db-instance \
-    --db-instance-identifier "$instance_id" \
-    --region ap-northeast-1 >/dev/null
-  echo "$instance_id を再起動中..."
-done
-```
-
-**期待される出力例**（2インスタンスの場合）:
-```
-aurora-bg-aurora-instance-1 を再起動中...
-aurora-bg-aurora-instance-2 を再起動中...
-```
-
-再起動完了まで待機：
-```bash
-aws-vault exec mizzy -- aws rds describe-db-instances \
-  --filters "Name=db-cluster-id,Values=aurora-bg-aurora-cluster" \
-  --region ap-northeast-1 \
-  --query 'DBInstances[*].DBInstanceIdentifier' \
-  --output text | tr '\t' '\n' | while read instance_id; do
-  echo "$instance_id の再起動完了を待機中..."
-  aws-vault exec mizzy -- aws rds wait db-instance-available \
-    --db-instance-identifier "$instance_id" \
-    --region ap-northeast-1
-  echo "$instance_id の再起動が完了しました"
-done
-
-echo "全インスタンスの再起動が完了しました"
-```
-
-**期待される出力例**（2インスタンスの場合）:
-```
-aurora-bg-aurora-instance-1 の再起動完了を待機中...
-aurora-bg-aurora-instance-1 の再起動が完了しました
-aurora-bg-aurora-instance-2 の再起動完了を待機中...
-aurora-bg-aurora-instance-2 の再起動が完了しました
-全インスタンスの再起動が完了しました
-```
-
-#### 7.4 最終動作確認
-```bash
-aws-vault exec mizzy -- aws rds describe-db-instances \
-  --filters "Name=db-cluster-id,Values=aurora-bg-aurora-cluster" \
-  --region ap-northeast-1 \
-  --query 'DBInstances[*].[DBInstanceIdentifier,DBInstanceStatus,EngineVersion]' \
-  --output table
-```
-
-**期待される出力例**（2インスタンスの場合）:
-```
--------------------------------------------------------
-|              DescribeDBInstances                    |
-+------------------------------+------------+---------+
-|  aurora-bg-aurora-instance-1 |  available |  15.10  |
-|  aurora-bg-aurora-instance-2 |  available |  15.10  |
-+------------------------------+------------+---------+
-```
-
-すべてのインスタンスが再起動後も `available` 状態で、バージョン `15.10` で稼働していることを確認します。
+**確認事項**:
+- [ ] すべてのインスタンスが `15.10` にアップグレードされている
+- [ ] すべてのインスタンスのステータスが `available` である
 
 ### 8. Terraformコードの更新
 
@@ -505,10 +562,8 @@ terraform plan
 No changes. Your infrastructure matches the configuration.
 ```
 
-もし差分が表示される場合は、以下を確認してください：
-- インスタンス名が正しいか
-- パラメータグループが正しく設定されているか
-- その他の設定が実際の環境と一致しているか
+**確認事項**:
+- [ ] Terraformの設定と実際の環境に差分がない
 
 #### 8.3 変更をコミット
 ```bash
@@ -518,8 +573,24 @@ git commit -m "chore: Update Aurora PostgreSQL version from 15.6 to 15.10 after 
 
 ### 9. ブルー/グリーン デプロイメントの削除
 
+時間をおいて実行する場合は、まずブルー/グリーン デプロイメントIDを取得します：
+
+```bash
+BG_DEPLOYMENT_ID=$(aws-vault exec mizzy -- aws rds describe-blue-green-deployments \
+  --region ap-northeast-1 \
+  --query 'BlueGreenDeployments[?Status==`SWITCHOVER_COMPLETED`].BlueGreenDeploymentIdentifier' \
+  --output text)
+
+echo "ブルー/グリーン デプロイメントID: $BG_DEPLOYMENT_ID"
+```
+
+**期待される出力例**:
+```
+ブルー/グリーン デプロイメントID: bgd-xxxxxxxxxxxxxxx
+```
+
 #### 9.1 ブルー/グリーン デプロイメントの削除
-スイッチオーバー完了後、問題がないことを確認してから ブルー/グリーン デプロイメントを削除します。
+スイッチオーバー完了後、問題がないことを確認してから ブルー/グリーン デプロイメントのリソースを削除します：
 
 ```bash
 aws-vault exec mizzy -- aws rds delete-blue-green-deployment \
@@ -527,11 +598,26 @@ aws-vault exec mizzy -- aws rds delete-blue-green-deployment \
   --region ap-northeast-1 >/dev/null
 ```
 
-**注意**: この時点で削除されるのはブルー/グリーン デプロイメントのリソースのみです。スイッチオーバー後に残された旧Blue環境（`aurora-bg-aurora-cluster-old1`）は自動的に削除されません。旧環境を削除する場合は、次の手順（9.2）で手動削除が必要です。
+削除を確認：
+```bash
+aws-vault exec mizzy -- aws rds describe-blue-green-deployments \
+  --blue-green-deployment-identifier $BG_DEPLOYMENT_ID \
+  --region ap-northeast-1 2>&1 | grep -q "BlueGreenDeploymentNotFoundFault" && \
+  echo "ブルー/グリーン デプロイメントが削除されました" || \
+  echo "削除処理中..."
+```
 
-#### 9.2 旧環境の削除（オプション）
+**期待される出力例**:
+```
+ブルー/グリーン デプロイメントが削除されました
+```
 
-旧環境のインスタンスを削除：
+**確認事項**:
+- [ ] ブルー/グリーン デプロイメントのリソースが削除された
+
+#### 9.2 旧環境のインスタンスを削除
+
+スイッチオーバー後に残された旧ブルー環境のインスタンスを削除します：
 ```bash
 aws-vault exec mizzy -- aws rds describe-db-instances \
   --filters "Name=db-cluster-id,Values=aurora-bg-aurora-cluster-old1" \
@@ -575,7 +661,12 @@ aurora-bg-aurora-instance-2-old1 の削除完了を待機中...
 aurora-bg-aurora-instance-2-old1 の削除が完了しました
 ```
 
-旧環境のクラスターを削除：
+**確認事項**:
+- [ ] すべての旧環境インスタンスが削除された
+
+#### 9.3 旧環境のクラスターを削除
+
+インスタンス削除後、旧ブルー環境のクラスターを削除します：
 ```bash
 aws-vault exec mizzy -- aws rds delete-db-cluster \
   --db-cluster-identifier aurora-bg-aurora-cluster-old1 \
@@ -603,6 +694,9 @@ echo "aurora-bg-aurora-cluster-old1 の削除が完了しました"
 クラスターの削除完了を待機中...
 aurora-bg-aurora-cluster-old1 の削除が完了しました
 ```
+
+**確認事項**:
+- [ ] 旧環境のクラスターが削除された
 
 ---
 
@@ -636,11 +730,20 @@ aws-vault exec mizzy -- aws rds describe-events \
 
 ## 注意事項
 
-1. **ダウンタイム**: スイッチオーバー中は短時間のダウンタイムが発生します（通常1-2分程度）
-2. **接続文字列**: エンドポイントは変更されないため、アプリケーション側の変更は不要です
-3. **パラメータグループ**: バージョンアップ後も同じパラメータグループファミリー（aurora-postgresql15）を使用できます
-4. **バックアップ**: スイッチオーバー前に手動スナップショットの取得を推奨します
-5. **テスト環境**: 本番環境での実施前に、テスト環境での検証を強く推奨します
+> [!IMPORTANT]
+> **ダウンタイム**: スイッチオーバー中は短時間のダウンタイムが発生します（通常1-2分程度）
+
+> [!NOTE]
+> **接続文字列**: エンドポイントは変更されないため、アプリケーション側の変更は不要です
+
+> [!NOTE]
+> **パラメータグループ**: バージョンアップ後も同じパラメータグループファミリー（aurora-postgresql15）を使用できます
+
+> [!WARNING]
+> **バックアップ**: スイッチオーバー前に手動スナップショットの取得を推奨します
+
+> [!CAUTION]
+> **テスト環境**: 本番環境での実施前に、テスト環境での検証を強く推奨します
 
 ---
 

--- a/aurora-blue-green-deployment/aurora-bg-upgrade-procedure.md
+++ b/aurora-blue-green-deployment/aurora-bg-upgrade-procedure.md
@@ -1,0 +1,651 @@
+# Aurora PostgreSQL ブルー/グリーン デプロイメントによるバージョンアップ手順書
+
+## 概要
+本手順書では、Aurora PostgreSQL クラスターを 15.6 から 15.10 へ、ブルー/グリーン デプロイメントを使用して安全にアップグレードする手順を説明します。
+
+## 前提条件
+- AWS CLI がインストールされていること
+- 適切な AWS 認証情報が設定されていること (`aws-vault exec mizzy --` を使用)
+- 現在の Aurora PostgreSQL バージョン: 15.6
+- ターゲットバージョン: 15.10
+
+## 現在の環境情報
+- **クラスター識別子**: aurora-bg-aurora-cluster
+- **インスタンス識別子プレフィックス**: aurora-bg-aurora-instance-
+- **リージョン**: ap-northeast-1
+
+---
+
+## 手順
+
+### 1. 事前確認
+
+#### 1.1 現在のクラスター情報を確認
+```bash
+aws-vault exec mizzy -- aws rds describe-db-clusters \
+  --db-cluster-identifier aurora-bg-aurora-cluster \
+  --region ap-northeast-1 \
+  --query 'DBClusters[0].[DBClusterIdentifier,EngineVersion,Status]' \
+  --output table
+```
+
+#### 1.2 現在のインスタンス情報を確認
+```bash
+aws-vault exec mizzy -- aws rds describe-db-instances \
+  --filters "Name=db-cluster-id,Values=aurora-bg-aurora-cluster" \
+  --region ap-northeast-1 \
+  --query 'DBInstances[*].[DBInstanceIdentifier,EngineVersion,DBInstanceStatus]' \
+  --output table
+```
+
+#### 1.3 ターゲットバージョン（15.10）が利用可能であることを確認
+```bash
+aws-vault exec mizzy -- aws rds describe-db-engine-versions \
+  --engine aurora-postgresql \
+  --engine-version 15.10 \
+  --region ap-northeast-1 \
+  --query 'DBEngineVersions[0].[Engine,EngineVersion,DBParameterGroupFamily]' \
+  --output table
+```
+
+バージョンが表示されれば、15.10へのアップグレードが可能です。
+
+### 2. 論理レプリケーションの有効化（必要な場合）
+
+Terraformで`rds.logical_replication = 1`を設定した後、インスタンスの再起動をしていない場合、設定を反映させるために再起動が必要です。
+
+#### 2.1 インスタンスを再起動して適用
+クラスター内の全インスタンスを個別に再起動：
+```bash
+aws-vault exec mizzy -- aws rds describe-db-instances \
+  --filters "Name=db-cluster-id,Values=aurora-bg-aurora-cluster" \
+  --region ap-northeast-1 \
+  --query 'DBInstances[*].DBInstanceIdentifier' \
+  --output text | tr '\t' '\n' | while read instance_id; do
+  aws-vault exec mizzy -- aws rds reboot-db-instance \
+    --db-instance-identifier "$instance_id" \
+    --region ap-northeast-1 >/dev/null
+  echo "$instance_id を再起動中..."
+done
+```
+
+**期待される出力例**（2インスタンスの場合）:
+```
+aurora-bg-aurora-instance-1 を再起動中...
+aurora-bg-aurora-instance-2 を再起動中...
+```
+
+再起動完了まで待機：
+```bash
+aws-vault exec mizzy -- aws rds describe-db-instances \
+  --filters "Name=db-cluster-id,Values=aurora-bg-aurora-cluster" \
+  --region ap-northeast-1 \
+  --query 'DBInstances[*].DBInstanceIdentifier' \
+  --output text | tr '\t' '\n' | while read instance_id; do
+  echo "$instance_id の再起動完了を待機中..."
+  aws-vault exec mizzy -- aws rds wait db-instance-available \
+    --db-instance-identifier "$instance_id" \
+    --region ap-northeast-1
+  echo "$instance_id の再起動が完了しました"
+done
+
+echo "全インスタンスの再起動が完了しました"
+```
+
+**期待される出力例**（2インスタンスの場合）:
+```
+aurora-bg-aurora-instance-1 の再起動が完了しました
+aurora-bg-aurora-instance-2 の再起動が完了しました
+全インスタンスの再起動が完了しました
+```
+
+### 3. ブルー/グリーン デプロイメントの作成
+
+#### 3.1 クラスターのARNを取得
+```bash
+CLUSTER_ARN=$(aws-vault exec mizzy -- aws rds describe-db-clusters \
+  --db-cluster-identifier aurora-bg-aurora-cluster \
+  --region ap-northeast-1 \
+  --query 'DBClusters[0].DBClusterArn' \
+  --output text)
+```
+
+```bash
+echo $CLUSTER_ARN
+```
+
+#### 3.2 ブルー/グリーン デプロイメントを作成
+```bash
+BG_DEPLOYMENT_ID=$(aws-vault exec mizzy -- aws rds create-blue-green-deployment \
+  --blue-green-deployment-name aurora-bg-upgrade-15-10 \
+  --source $CLUSTER_ARN \
+  --target-engine-version 15.10 \
+  --target-db-cluster-parameter-group-name aurora-bg-aurora-pg15-cluster-params \
+  --target-db-parameter-group-name aurora-bg-aurora-pg15-params \
+  --region ap-northeast-1 \
+  --query 'BlueGreenDeployment.BlueGreenDeploymentIdentifier' \
+  --output text)
+```
+
+```bash
+echo $BG_DEPLOYMENT_ID
+```
+
+#### 3.3 デプロイメントのステータスを確認
+```bash
+aws-vault exec mizzy -- aws rds describe-blue-green-deployments \
+  --blue-green-deployment-identifier $BG_DEPLOYMENT_ID \
+  --region ap-northeast-1 \
+  --query 'BlueGreenDeployments[0].[BlueGreenDeploymentIdentifier,Status,StatusDetails]' \
+  --output table
+```
+
+**期待される出力例**:
+```
+-----------------------------------------------
+|       DescribeBlueGreenDeployments         |
++---------------------------------------------+
+|  bgd-xxxxxxxxxxxxxxx                       |
+|  PROVISIONING                               |
+|  None                                       |
++---------------------------------------------+
+```
+
+`PROVISIONING`はグリーン環境を作成中の状態です。
+
+#### 3.4 デプロイメントが利用可能になるまで待機
+**注意**: グリーン環境の作成には時間がかかります（データベースのサイズやインスタンス数により30分〜1時間以上）。
+
+```bash
+while true; do
+  STATUS=$(aws-vault exec mizzy -- aws rds describe-blue-green-deployments \
+    --blue-green-deployment-identifier $BG_DEPLOYMENT_ID \
+    --region ap-northeast-1 \
+    --query 'BlueGreenDeployments[0].Status' \
+    --output text)
+  
+  echo "$(date): ステータス = $STATUS"
+  
+  if [ "$STATUS" = "AVAILABLE" ]; then
+    echo "ブルー/グリーン デプロイメントが利用可能になりました"
+    break
+  elif [ "$STATUS" = "PROVISIONING_FAILED" ] || [ "$STATUS" = "INVALID_CONFIGURATION" ]; then
+    echo "ブルー/グリーン デプロイメントの作成に失敗しました"
+    exit 1
+  fi
+  
+  sleep 30
+done
+```
+
+**期待される出力例**:
+```
+Wed Jan 15 10:30:00 JST 2025: ステータス = PROVISIONING
+Wed Jan 15 10:30:30 JST 2025: ステータス = PROVISIONING
+Wed Jan 15 10:31:00 JST 2025: ステータス = PROVISIONING
+...（15〜60分程度続く）...
+Wed Jan 15 10:45:00 JST 2025: ステータス = AVAILABLE
+ブルー/グリーン デプロイメントが利用可能になりました
+```
+
+### 4. グリーン環境の再起動
+
+#### 4.1 グリーン環境のクラスター識別子を取得
+```bash
+GREEN_CLUSTER_ARN=$(aws-vault exec mizzy -- aws rds describe-blue-green-deployments \
+  --blue-green-deployment-identifier $BG_DEPLOYMENT_ID \
+  --region ap-northeast-1 \
+  --query 'BlueGreenDeployments[0].Target' \
+  --output text)
+
+GREEN_CLUSTER_ID=$(echo $GREEN_CLUSTER_ARN | awk -F: '{print $NF}')
+```
+
+```bash
+echo $GREEN_CLUSTER_ID
+```
+
+#### 4.2 グリーン環境のインスタンスを再起動
+アップグレード後のパラメータ適用を確実に行うため、グリーン環境のすべてのインスタンスを再起動します：
+
+```bash
+aws-vault exec mizzy -- aws rds describe-db-instances \
+  --filters "Name=db-cluster-id,Values=$GREEN_CLUSTER_ID" \
+  --region ap-northeast-1 \
+  --query 'DBInstances[*].DBInstanceIdentifier' \
+  --output text | tr '\t' '\n' | while read instance_id; do
+  aws-vault exec mizzy -- aws rds reboot-db-instance \
+    --db-instance-identifier "$instance_id" \
+    --region ap-northeast-1 >/dev/null
+  echo "$instance_id を再起動中..."
+done
+```
+
+**期待される出力例**（2インスタンスの場合）:
+```
+aurora-bg-aurora-cluster-green-xxxxxx-instance-1 を再起動中...
+aurora-bg-aurora-cluster-green-xxxxxx-instance-2 を再起動中...
+```
+
+再起動完了まで待機：
+```bash
+aws-vault exec mizzy -- aws rds describe-db-instances \
+  --filters "Name=db-cluster-id,Values=$GREEN_CLUSTER_ID" \
+  --region ap-northeast-1 \
+  --query 'DBInstances[*].DBInstanceIdentifier' \
+  --output text | tr '\t' '\n' | while read instance_id; do
+  echo "$instance_id の再起動完了を待機中..."
+  aws-vault exec mizzy -- aws rds wait db-instance-available \
+    --db-instance-identifier "$instance_id" \
+    --region ap-northeast-1
+  echo "$instance_id の再起動が完了しました"
+done
+
+echo "グリーン環境の全インスタンスの再起動が完了しました"
+```
+
+**期待される出力例**（2インスタンスの場合）:
+```
+aurora-bg-aurora-cluster-green-xxxxxx-instance-1 の再起動完了を待機中...
+aurora-bg-aurora-cluster-green-xxxxxx-instance-1 の再起動が完了しました
+aurora-bg-aurora-cluster-green-xxxxxx-instance-2 の再起動完了を待機中...
+aurora-bg-aurora-cluster-green-xxxxxx-instance-2 の再起動が完了しました
+グリーン環境の全インスタンスの再起動が完了しました
+```
+
+### 5. グリーン環境の検証（オプション）
+
+グリーン環境のエンドポイントを使用して、アプリケーションの動作確認を行います。
+
+```bash
+GREEN_ENDPOINT=$(aws-vault exec mizzy -- aws rds describe-db-clusters \
+  --db-cluster-identifier $GREEN_CLUSTER_ID \
+  --region ap-northeast-1 \
+  --query 'DBClusters[0].Endpoint' \
+  --output text)
+```
+
+```bash
+echo $GREEN_ENDPOINT
+```
+
+### 6. スイッチオーバーの実行
+
+#### 6.1 スイッチオーバー前のスナップショット取得
+スイッチオーバー前に、現在のBlue環境（本番環境）のスナップショットを取得します：
+
+```bash
+SNAPSHOT_ID="aurora-bg-aurora-cluster-before-switchover-$(date +%Y%m%d-%H%M%S)"
+
+aws-vault exec mizzy -- aws rds create-db-cluster-snapshot \
+  --db-cluster-snapshot-identifier $SNAPSHOT_ID \
+  --db-cluster-identifier aurora-bg-aurora-cluster \
+  --region ap-northeast-1 >/dev/null
+
+echo "スナップショット $SNAPSHOT_ID を作成中..."
+
+aws-vault exec mizzy -- aws rds wait db-cluster-snapshot-completed \
+  --db-cluster-snapshot-identifier $SNAPSHOT_ID \
+  --region ap-northeast-1
+
+echo "スナップショットの作成が完了しました"
+```
+
+**期待される出力例**:
+```
+スナップショット aurora-bg-aurora-cluster-before-switchover-20250115-110000 を作成中...
+スナップショットの作成が完了しました
+```
+
+#### 6.2 スイッチオーバー前の最終確認
+```bash
+aws-vault exec mizzy -- aws rds describe-blue-green-deployments \
+  --blue-green-deployment-identifier $BG_DEPLOYMENT_ID \
+  --region ap-northeast-1 \
+  --query 'BlueGreenDeployments[0].[Status,StatusDetails]' \
+  --output table
+```
+
+**期待される出力例**:
+```
+------------------------------
+|DescribeBlueGreenDeployments|
++----------------------------+
+|  AVAILABLE                 |
+|  None                      |
++----------------------------+
+```
+
+この出力は正常な状態を示しています：
+- `AVAILABLE`: スイッチオーバー可能な状態
+- `None`: エラーや警告がない正常な状態
+
+#### 6.3 スイッチオーバーを実行して完了を待機
+**注意**: スイッチオーバーは通常数分で完了しますが、この間データベースへの接続が一時的に切断されます。
+
+```bash
+aws-vault exec mizzy -- aws rds switchover-blue-green-deployment \
+  --blue-green-deployment-identifier $BG_DEPLOYMENT_ID \
+  --region ap-northeast-1 >/dev/null
+
+echo "スイッチオーバーを開始しました"
+
+while true; do
+  STATUS=$(aws-vault exec mizzy -- aws rds describe-blue-green-deployments \
+    --blue-green-deployment-identifier $BG_DEPLOYMENT_ID \
+    --region ap-northeast-1 \
+    --query 'BlueGreenDeployments[0].Status' \
+    --output text)
+  
+  echo "$(date): ステータス = $STATUS"
+  
+  if [ "$STATUS" = "SWITCHOVER_COMPLETED" ]; then
+    echo "スイッチオーバーが完了しました"
+    break
+  elif [ "$STATUS" = "SWITCHOVER_FAILED" ]; then
+    echo "スイッチオーバーに失敗しました"
+    exit 1
+  fi
+  
+  sleep 30
+done
+```
+
+**期待される出力例**:
+```
+スイッチオーバーを開始しました
+Wed Jan 15 11:00:00 JST 2025: ステータス = SWITCHOVER_IN_PROGRESS
+Wed Jan 15 11:00:30 JST 2025: ステータス = SWITCHOVER_IN_PROGRESS
+Wed Jan 15 11:01:00 JST 2025: ステータス = SWITCHOVER_IN_PROGRESS
+Wed Jan 15 11:01:30 JST 2025: ステータス = SWITCHOVER_IN_PROGRESS
+Wed Jan 15 11:02:00 JST 2025: ステータス = SWITCHOVER_COMPLETED
+スイッチオーバーが完了しました
+```
+
+### 7. アップグレード後の確認と再起動
+
+#### 7.1 アップグレード後のクラスターバージョンを確認
+```bash
+aws-vault exec mizzy -- aws rds describe-db-clusters \
+  --db-cluster-identifier aurora-bg-aurora-cluster \
+  --region ap-northeast-1 \
+  --query 'DBClusters[0].[DBClusterIdentifier,EngineVersion,Status]' \
+  --output table
+```
+
+**期待される出力例**:
+```
+---------------------------------------------
+|           DescribeDBClusters              |
++-------------------------------------------+
+|  aurora-bg-aurora-cluster                 |
+|  15.10                                    |
+|  available                                |
++-------------------------------------------+
+```
+
+バージョンが `15.10` にアップグレードされていることを確認します。
+
+#### 7.2 インスタンスのバージョンを確認
+```bash
+aws-vault exec mizzy -- aws rds describe-db-instances \
+  --filters "Name=db-cluster-id,Values=aurora-bg-aurora-cluster" \
+  --region ap-northeast-1 \
+  --query 'DBInstances[*].[DBInstanceIdentifier,EngineVersion,DBInstanceStatus]' \
+  --output table
+```
+
+**期待される出力例**（2インスタンスの場合）:
+```
+-------------------------------------------------------
+|              DescribeDBInstances                    |
++------------------------------+---------+------------+
+|  aurora-bg-aurora-instance-1 |  15.10  |  available |
+|  aurora-bg-aurora-instance-2 |  15.10  |  available |
++------------------------------+---------+------------+
+```
+
+すべてのインスタンスが `15.10` にアップグレードされ、`available` 状態であることを確認します。
+
+#### 7.3 インスタンスの再起動
+スイッチオーバー後、パラメータグループの完全な同期のため、すべてのインスタンスを再起動します：
+
+```bash
+aws-vault exec mizzy -- aws rds describe-db-instances \
+  --filters "Name=db-cluster-id,Values=aurora-bg-aurora-cluster" \
+  --region ap-northeast-1 \
+  --query 'DBInstances[*].DBInstanceIdentifier' \
+  --output text | tr '\t' '\n' | while read instance_id; do
+  aws-vault exec mizzy -- aws rds reboot-db-instance \
+    --db-instance-identifier "$instance_id" \
+    --region ap-northeast-1 >/dev/null
+  echo "$instance_id を再起動中..."
+done
+```
+
+**期待される出力例**（2インスタンスの場合）:
+```
+aurora-bg-aurora-instance-1 を再起動中...
+aurora-bg-aurora-instance-2 を再起動中...
+```
+
+再起動完了まで待機：
+```bash
+aws-vault exec mizzy -- aws rds describe-db-instances \
+  --filters "Name=db-cluster-id,Values=aurora-bg-aurora-cluster" \
+  --region ap-northeast-1 \
+  --query 'DBInstances[*].DBInstanceIdentifier' \
+  --output text | tr '\t' '\n' | while read instance_id; do
+  echo "$instance_id の再起動完了を待機中..."
+  aws-vault exec mizzy -- aws rds wait db-instance-available \
+    --db-instance-identifier "$instance_id" \
+    --region ap-northeast-1
+  echo "$instance_id の再起動が完了しました"
+done
+
+echo "全インスタンスの再起動が完了しました"
+```
+
+**期待される出力例**（2インスタンスの場合）:
+```
+aurora-bg-aurora-instance-1 の再起動完了を待機中...
+aurora-bg-aurora-instance-1 の再起動が完了しました
+aurora-bg-aurora-instance-2 の再起動完了を待機中...
+aurora-bg-aurora-instance-2 の再起動が完了しました
+全インスタンスの再起動が完了しました
+```
+
+#### 7.4 最終動作確認
+```bash
+aws-vault exec mizzy -- aws rds describe-db-instances \
+  --filters "Name=db-cluster-id,Values=aurora-bg-aurora-cluster" \
+  --region ap-northeast-1 \
+  --query 'DBInstances[*].[DBInstanceIdentifier,DBInstanceStatus,EngineVersion]' \
+  --output table
+```
+
+**期待される出力例**（2インスタンスの場合）:
+```
+-------------------------------------------------------
+|              DescribeDBInstances                    |
++------------------------------+------------+---------+
+|  aurora-bg-aurora-instance-1 |  available |  15.10  |
+|  aurora-bg-aurora-instance-2 |  available |  15.10  |
++------------------------------+------------+---------+
+```
+
+すべてのインスタンスが再起動後も `available` 状態で、バージョン `15.10` で稼働していることを確認します。
+
+### 8. Terraformコードの更新
+
+スイッチオーバー完了後、Terraformコードのバージョンを更新して、実際の環境と一致させます。
+
+#### 8.1 aurora.tfのバージョンを更新
+```bash
+# 現在のバージョンを確認
+grep "engine_version" aurora.tf
+```
+
+aurora.tf を編集して、エンジンバージョンを更新：
+```hcl
+# 変更前
+engine_version = "15.6"
+
+# 変更後
+engine_version = "15.10"
+```
+
+#### 8.2 Terraform実行計画を確認
+```bash
+terraform plan
+```
+
+**期待される出力**:
+```
+No changes. Your infrastructure matches the configuration.
+```
+
+もし差分が表示される場合は、以下を確認してください：
+- インスタンス名が正しいか
+- パラメータグループが正しく設定されているか
+- その他の設定が実際の環境と一致しているか
+
+#### 8.3 変更をコミット
+```bash
+git add aurora.tf
+git commit -m "chore: Update Aurora PostgreSQL version from 15.6 to 15.10 after Blue/Green deployment"
+```
+
+### 9. ブルー/グリーン デプロイメントの削除
+
+#### 9.1 ブルー/グリーン デプロイメントの削除
+スイッチオーバー完了後、問題がないことを確認してから ブルー/グリーン デプロイメントを削除します。
+
+```bash
+aws-vault exec mizzy -- aws rds delete-blue-green-deployment \
+  --blue-green-deployment-identifier $BG_DEPLOYMENT_ID \
+  --region ap-northeast-1 >/dev/null
+```
+
+**注意**: この時点で削除されるのはブルー/グリーン デプロイメントのリソースのみです。スイッチオーバー後に残された旧Blue環境（`aurora-bg-aurora-cluster-old1`）は自動的に削除されません。旧環境を削除する場合は、次の手順（9.2）で手動削除が必要です。
+
+#### 9.2 旧環境の削除（オプション）
+
+旧環境のインスタンスを削除：
+```bash
+aws-vault exec mizzy -- aws rds describe-db-instances \
+  --filters "Name=db-cluster-id,Values=aurora-bg-aurora-cluster-old1" \
+  --region ap-northeast-1 \
+  --query 'DBInstances[*].DBInstanceIdentifier' \
+  --output text | tr '\t' '\n' | while read instance_id; do
+  aws-vault exec mizzy -- aws rds delete-db-instance \
+    --db-instance-identifier "$instance_id" \
+    --skip-final-snapshot \
+    --region ap-northeast-1 >/dev/null
+  echo "$instance_id を削除中..."
+done
+```
+
+**期待される出力例**（2インスタンスの場合）:
+```
+aurora-bg-aurora-instance-1-old1 を削除中...
+aurora-bg-aurora-instance-2-old1 を削除中...
+```
+
+インスタンス削除完了まで待機：
+```bash
+aws-vault exec mizzy -- aws rds describe-db-instances \
+  --filters "Name=db-cluster-id,Values=aurora-bg-aurora-cluster-old1" \
+  --region ap-northeast-1 \
+  --query 'DBInstances[*].DBInstanceIdentifier' \
+  --output text | tr '\t' '\n' | while read instance_id; do
+  echo "$instance_id の削除完了を待機中..."
+  aws-vault exec mizzy -- aws rds wait db-instance-deleted \
+    --db-instance-identifier "$instance_id" \
+    --region ap-northeast-1
+  echo "$instance_id の削除が完了しました"
+done
+```
+
+**期待される出力例**（2インスタンスの場合）:
+```
+aurora-bg-aurora-instance-1-old1 の削除完了を待機中...
+aurora-bg-aurora-instance-1-old1 の削除が完了しました
+aurora-bg-aurora-instance-2-old1 の削除完了を待機中...
+aurora-bg-aurora-instance-2-old1 の削除が完了しました
+```
+
+旧環境のクラスターを削除：
+```bash
+aws-vault exec mizzy -- aws rds delete-db-cluster \
+  --db-cluster-identifier aurora-bg-aurora-cluster-old1 \
+  --skip-final-snapshot \
+  --region ap-northeast-1 >/dev/null
+echo "aurora-bg-aurora-cluster-old1 を削除中..."
+```
+
+**期待される出力例**:
+```
+aurora-bg-aurora-cluster-old1 を削除中...
+```
+
+クラスター削除完了まで待機：
+```bash
+echo "クラスターの削除完了を待機中..."
+aws-vault exec mizzy -- aws rds wait db-cluster-deleted \
+  --db-cluster-identifier aurora-bg-aurora-cluster-old1 \
+  --region ap-northeast-1
+echo "aurora-bg-aurora-cluster-old1 の削除が完了しました"
+```
+
+**期待される出力例**:
+```
+クラスターの削除完了を待機中...
+aurora-bg-aurora-cluster-old1 の削除が完了しました
+```
+
+---
+
+## ロールバック手順
+
+スイッチオーバー後に問題が発生した場合のロールバック手順については、以下のドキュメントを参照してください：
+
+**[Aurora PostgreSQL ブルー/グリーン デプロイメント ロールバック手順書](./aurora-bg-rollback-procedure.md)**
+
+---
+
+## トラブルシューティング
+
+### ブルー/グリーン デプロイメントのステータスが「PROVISIONING」で止まっている場合
+- パラメータグループの互換性を確認
+- セキュリティグループの設定を確認
+- サブネットグループの設定を確認
+
+### スイッチオーバーが失敗した場合
+- CloudWatch Logs でエラーメッセージを確認
+- RDS イベントログを確認：
+```bash
+aws-vault exec mizzy -- aws rds describe-events \
+  --source-identifier aurora-bg-aurora-cluster \
+  --source-type db-cluster \
+  --region ap-northeast-1 \
+  --duration 60
+```
+
+---
+
+## 注意事項
+
+1. **ダウンタイム**: スイッチオーバー中は短時間のダウンタイムが発生します（通常1-2分程度）
+2. **接続文字列**: エンドポイントは変更されないため、アプリケーション側の変更は不要です
+3. **パラメータグループ**: バージョンアップ後も同じパラメータグループファミリー（aurora-postgresql15）を使用できます
+4. **バックアップ**: スイッチオーバー前に手動スナップショットの取得を推奨します
+5. **テスト環境**: 本番環境での実施前に、テスト環境での検証を強く推奨します
+
+---
+
+## 参考情報
+
+- [AWS Documentation: Blue/Green Deployments for Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/blue-green-deployments.html)
+- [AWS CLI Reference: create-blue-green-deployment](https://docs.aws.amazon.com/cli/latest/reference/rds/create-blue-green-deployment.html)
+- [AWS CLI Reference: switchover-blue-green-deployment](https://docs.aws.amazon.com/cli/latest/reference/rds/switchover-blue-green-deployment.html)

--- a/aurora-blue-green-deployment/aurora.tf
+++ b/aurora-blue-green-deployment/aurora.tf
@@ -1,0 +1,179 @@
+# DB Subnet Group
+resource "aws_db_subnet_group" "aurora" {
+  name       = "${var.name_prefix}-aurora-subnet-group"
+  subnet_ids = [for s in module.vpc.private_subnets : s.id]
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.name_prefix}-aurora-subnet-group"
+    }
+  )
+}
+
+# Security Group for Aurora
+resource "aws_security_group" "aurora" {
+  name        = "${var.name_prefix}-aurora-sg"
+  description = "Security group for Aurora PostgreSQL cluster"
+  vpc_id      = module.vpc.id
+
+  ingress {
+    description = "PostgreSQL from VPC"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  egress {
+    description = "Allow all outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.name_prefix}-aurora-sg"
+    }
+  )
+}
+
+# RDS Cluster Parameter Group
+resource "aws_rds_cluster_parameter_group" "aurora_postgresql" {
+  family      = "aurora-postgresql15"
+  name        = "${var.name_prefix}-aurora-pg15-cluster-params"
+  description = "Aurora PostgreSQL 15 cluster parameter group"
+
+  # Blue/Green deployment parameters
+  parameter {
+    name         = "rds.logical_replication"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
+
+  tags = var.tags
+}
+
+# DB Parameter Group
+resource "aws_db_parameter_group" "aurora_postgresql" {
+  family      = "aurora-postgresql15"
+  name        = "${var.name_prefix}-aurora-pg15-params"
+  description = "Aurora PostgreSQL 15 parameter group"
+
+  tags = var.tags
+}
+
+# Aurora Cluster
+resource "aws_rds_cluster" "aurora_postgresql" {
+  cluster_identifier              = "${var.name_prefix}-aurora-cluster"
+  engine                          = "aurora-postgresql"
+  engine_version                  = "15.6"
+  database_name                   = var.database_name
+  master_username                 = var.master_username
+  master_password                 = var.master_password
+  db_subnet_group_name            = aws_db_subnet_group.aurora.name
+  vpc_security_group_ids          = [aws_security_group.aurora.id]
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.aurora_postgresql.name
+
+  backup_retention_period = var.backup_retention_period
+  preferred_backup_window = var.backup_window
+  preferred_maintenance_window = var.maintenance_window
+
+  skip_final_snapshot       = var.skip_final_snapshot
+  final_snapshot_identifier = var.skip_final_snapshot ? null : "${var.name_prefix}-aurora-final-snapshot-${formatdate("YYYY-MM-DD-hhmm", timestamp())}"
+
+  enabled_cloudwatch_logs_exports = ["postgresql"]
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.name_prefix}-aurora-cluster"
+    }
+  )
+}
+
+# Aurora Instances
+resource "aws_rds_cluster_instance" "aurora_instance" {
+  count = var.instance_count
+  
+  identifier                   = "${var.name_prefix}-aurora-instance-${count.index + 1}"
+  cluster_identifier           = aws_rds_cluster.aurora_postgresql.id
+  instance_class               = var.instance_class
+  engine                       = aws_rds_cluster.aurora_postgresql.engine
+  engine_version               = aws_rds_cluster.aurora_postgresql.engine_version
+  db_parameter_group_name      = aws_db_parameter_group.aurora_postgresql.name
+  
+  performance_insights_enabled = var.performance_insights_enabled
+  monitoring_interval          = var.monitoring_interval
+  monitoring_role_arn          = var.monitoring_interval > 0 ? aws_iam_role.rds_enhanced_monitoring[0].arn : null
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.name_prefix}-aurora-instance-${count.index + 1}"
+    }
+  )
+}
+
+# IAM Role for Enhanced Monitoring (optional)
+resource "aws_iam_role" "rds_enhanced_monitoring" {
+  count = var.monitoring_interval > 0 ? 1 : 0
+
+  name = "${var.name_prefix}-rds-enhanced-monitoring"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "monitoring.rds.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
+  count = var.monitoring_interval > 0 ? 1 : 0
+
+  role       = aws_iam_role.rds_enhanced_monitoring[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}
+
+# Outputs
+output "aurora_cluster_endpoint" {
+  description = "The cluster endpoint"
+  value       = aws_rds_cluster.aurora_postgresql.endpoint
+}
+
+output "aurora_cluster_reader_endpoint" {
+  description = "The cluster reader endpoint"
+  value       = aws_rds_cluster.aurora_postgresql.reader_endpoint
+}
+
+output "aurora_cluster_id" {
+  description = "The RDS Cluster ID"
+  value       = aws_rds_cluster.aurora_postgresql.id
+}
+
+output "aurora_instance_ids" {
+  description = "List of RDS instance identifiers"
+  value       = aws_rds_cluster_instance.aurora_instance[*].id
+}
+
+output "aurora_instance_endpoints" {
+  description = "List of RDS instance endpoints"
+  value       = aws_rds_cluster_instance.aurora_instance[*].endpoint
+}
+
+output "aurora_security_group_id" {
+  description = "The security group ID for Aurora"
+  value       = aws_security_group.aurora.id
+}

--- a/aurora-blue-green-deployment/blue-green-prerequisites.md
+++ b/aurora-blue-green-deployment/blue-green-prerequisites.md
@@ -1,0 +1,78 @@
+# Aurora PostgreSQL ブルー/グリーン デプロイメント前提条件
+
+## 必須パラメータ設定（AWS公式ドキュメント準拠）
+
+### 1. 必須パラメータ
+- `rds.logical_replication = 1` - 論理レプリケーションを有効化（**必須**）
+- `synchronous_commit = on` - データ整合性を保証（**必須**）
+
+### 2. ワーカープロセス設定
+AWS公式ドキュメント（[Setting up logical replication](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Replication.Logical.Configure.html)）によると、以下のパラメータについて記載があります：
+
+> "In many cases, the default values are sufficient."
+
+以下のパラメータはデフォルト値で十分です：
+- `max_replication_slots` - デフォルト値で十分
+- `max_logical_replication_workers` - デフォルト値で十分  
+- `max_worker_processes` - デフォルト値で十分（GREATEST(${DBInstanceVCPU*2},8)）
+
+**参照**: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Replication.Logical.Configure.html
+
+### 3. 拡張機能の制限
+**以下の拡張機能は無効にする必要があります：**
+- `pglogical` - shared_preload_libraries から削除
+- `pgactive` - 使用しない
+- `pg_partman` - 使用しない
+- `pg_cron` - Green環境では無効化
+
+## データベース要件
+
+### 1. プライマリキー
+- **すべてのテーブルにプライマリキーが必要**
+- プライマリキーがない場合は `REPLICA IDENTITY FULL` を設定
+
+### 2. レプリケーションされない要素
+以下は Blue から Green にレプリケーションされません：
+- DDL文（CREATE TABLE, ALTER TABLE など）
+- DCL文（GRANT, REVOKE など）
+- シーケンス値
+- ラージオブジェクト
+- マテリアライズドビューの更新
+
+## パフォーマンス考慮事項
+
+### 1. 書き込み負荷
+- 高い書き込みトラフィックはレプリケーション遅延を引き起こす可能性
+- 必要に応じてインスタンスクラスをスケールアップ
+
+### 2. データベース数
+- データベース数が多いとリソースオーバーヘッドが増加
+
+## 推奨事項
+
+1. **事前テスト**: 本番環境での実施前に、テスト環境で十分に検証
+2. **バックアップ**: Blue/Green デプロイメント作成前に手動スナップショットを取得
+3. **監視**: レプリケーション遅延を監視
+4. **タイミング**: 負荷の低い時間帯に実施
+
+## 制限事項
+
+### Aurora PostgreSQL バージョン
+- Aurora PostgreSQL 10.13 以降が必要
+- Babelfish は 15.7+ および 16.3+ でサポート
+
+### 操作の制限
+- 新しいパーティションの作成はサポートされない
+- 論理レプリケーションの適用プロセスはシングルスレッド
+
+## チェックリスト
+
+ブルー/グリーン デプロイメント実施前の確認項目：
+
+- [ ] `rds.logical_replication = 1` が設定されている
+- [ ] pglogical 拡張機能が無効になっている
+- [ ] すべてのテーブルにプライマリキーがある
+- [ ] パラメータグループが正しく設定されている
+- [ ] インスタンスが再起動済みで設定が反映されている
+- [ ] 手動スナップショットを取得済み
+- [ ] アプリケーションの停止計画が準備できている

--- a/aurora-blue-green-deployment/terraform.tf
+++ b/aurora-blue-green-deployment/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/aurora-blue-green-deployment/variables.tf
+++ b/aurora-blue-green-deployment/variables.tf
@@ -1,0 +1,113 @@
+variable "name_prefix" {
+  description = "Prefix for resource names"
+  type        = string
+  default     = "aurora-bg"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "availability_zones" {
+  description = "List of availability zones"
+  type        = list(string)
+  default     = ["ap-northeast-1a", "ap-northeast-1c"]
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets"
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for private subnets"
+  type        = list(string)
+  default     = ["10.0.11.0/24", "10.0.12.0/24"]
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default = {
+    Environment = "development"
+    Project     = "aurora-blue-green-deployment"
+  }
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+# Aurora Variables
+variable "database_name" {
+  description = "The name of the database"
+  type        = string
+  default     = "mydb"
+}
+
+variable "master_username" {
+  description = "The master username for the database"
+  type        = string
+  default     = "postgres"
+  sensitive   = true
+}
+
+variable "master_password" {
+  description = "The master password for the database"
+  type        = string
+  default     = "ChangeMe123!"
+  sensitive   = true
+}
+
+variable "instance_class" {
+  description = "The instance class for Aurora instances"
+  type        = string
+  default     = "db.t4g.medium"
+}
+
+variable "instance_count" {
+  description = "Number of Aurora instances in the cluster"
+  type        = number
+  default     = 2
+}
+
+variable "backup_retention_period" {
+  description = "The backup retention period in days"
+  type        = number
+  default     = 7
+}
+
+variable "backup_window" {
+  description = "The preferred backup window"
+  type        = string
+  default     = "03:00-04:00"
+}
+
+variable "maintenance_window" {
+  description = "The preferred maintenance window"
+  type        = string
+  default     = "sun:04:00-sun:05:00"
+}
+
+variable "skip_final_snapshot" {
+  description = "Skip final snapshot when destroying"
+  type        = bool
+  default     = true
+}
+
+variable "performance_insights_enabled" {
+  description = "Enable Performance Insights"
+  type        = bool
+  default     = true
+}
+
+variable "monitoring_interval" {
+  description = "The interval for collecting enhanced monitoring metrics"
+  type        = number
+  default     = 60
+}

--- a/aurora-blue-green-deployment/vpc.tf
+++ b/aurora-blue-green-deployment/vpc.tf
@@ -1,0 +1,21 @@
+module "vpc" {
+  source = "git::https://github.com/mizzy/terraform-modules.git//aws/vpc?ref=main"
+
+  name       = var.name_prefix
+  cidr_block = var.vpc_cidr
+}
+
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = module.vpc.id
+}
+
+output "public_subnets" {
+  description = "Public subnets"
+  value       = module.vpc.public_subnets
+}
+
+output "private_subnets" {
+  description = "Private subnets"
+  value       = module.vpc.private_subnets
+}


### PR DESCRIPTION
## Summary
- Added complete Terraform configuration for Aurora PostgreSQL with Blue/Green deployment capability
- Created comprehensive upgrade and rollback procedures with step-by-step instructions
- Configured logical replication parameters required for Blue/Green deployments

## Changes
### Terraform Configuration
- **aurora.tf**: Aurora PostgreSQL 15.6 cluster with Blue/Green deployment parameters
- **vpc.tf**: VPC configuration with public/private subnets
- **variables.tf**: Configurable parameters for the deployment
- **terraform.tf**: Provider and backend configuration

### Documentation
- **aurora-bg-upgrade-procedure.md**: Step-by-step upgrade procedure from 15.6 to 15.10
- **aurora-bg-rollback-procedure.md**: Rollback procedures for post-switchover recovery
- **blue-green-prerequisites.md**: Prerequisites and requirements for Blue/Green deployment

## Key Features
- Logical replication enabled (`rds.logical_replication=1`)
- Manual snapshot creation before switchover
- Expected output examples for each step
- Japanese language messages for better usability
- Terraform code update instructions post-switchover
- Separate rollback procedures for different scenarios

## Test Plan
- [ ] Run `terraform init` and `terraform plan`
- [ ] Deploy Aurora cluster with `terraform apply`
- [ ] Test Blue/Green deployment creation
- [ ] Verify switchover process
- [ ] Test rollback procedures
- [ ] Validate Terraform state after switchover

🤖 Generated with [Claude Code](https://claude.ai/code)