### PR TITLE
feat: Add service account IAM binding configuration

### DIFF
--- a/service-account-iam-binding/.terraform.lock.hcl
+++ b/service-account-iam-binding/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:iy2Q9VcnMu4z/bH3v/NmI/nEpgYY7bXgJmT/hVTAUS4=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/service-account-iam-binding/iam/.terraform.lock.hcl
+++ b/service-account-iam-binding/iam/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:iy2Q9VcnMu4z/bH3v/NmI/nEpgYY7bXgJmT/hVTAUS4=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/service-account-iam-binding/iam/main.tf
+++ b/service-account-iam-binding/iam/main.tf
@@ -1,0 +1,68 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+resource "google_service_account" "terraform_deployer" {
+  account_id   = "terraform-deployer"
+  display_name = "Terraform Deployer Service Account"
+  description  = "Service account for deploying Terraform resources"
+}
+
+resource "google_project_iam_custom_role" "terraform_deployer_role" {
+  role_id     = "terraformDeployer"
+  title       = "Terraform Deployer"
+  description = "Custom role for Terraform deployment with minimal permissions"
+
+  permissions = [
+    "iam.serviceAccounts.create",
+    "iam.serviceAccounts.delete",
+    "iam.serviceAccounts.get",
+    "iam.serviceAccounts.list",
+    "iam.serviceAccounts.update",
+    "iam.serviceAccounts.getIamPolicy",
+    "iam.serviceAccounts.setIamPolicy"
+  ]
+}
+
+resource "google_project_iam_member" "terraform_deployer_binding" {
+  project = var.project_id
+  role    = google_project_iam_custom_role.terraform_deployer_role.id
+  member  = "serviceAccount:${google_service_account.terraform_deployer.email}"
+}
+
+output "service_account_email" {
+  description = "Email of the Terraform deployer service account"
+  value       = google_service_account.terraform_deployer.email
+}
+
+resource "google_service_account_iam_member" "token_creator" {
+  service_account_id = google_service_account.terraform_deployer.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "user:gosukenator@gmail.com"
+}
+
+output "custom_role_id" {
+  description = "ID of the custom role"
+  value       = google_project_iam_custom_role.terraform_deployer_role.id
+}

--- a/service-account-iam-binding/main.tf
+++ b/service-account-iam-binding/main.tf
@@ -1,0 +1,32 @@
+resource "google_service_account" "example" {
+  account_id   = "example-service-account"
+  display_name = "Example Service Account"
+  description  = "Example service account for IAM binding demonstration"
+}
+
+resource "google_service_account_iam_binding" "token_creator" {
+  service_account_id = google_service_account.example.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+
+  members = [
+    "user:gosukenator@gmail.com",
+  ]
+}
+
+resource "google_service_account_iam_binding" "user" {
+  service_account_id = google_service_account.example.name
+  role               = "roles/iam.serviceAccountUser"
+
+  members = [
+    "user:gosukenator@gmail.com",
+  ]
+}
+
+resource "google_service_account_iam_binding" "impersonator" {
+  service_account_id = google_service_account.example.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+
+  members = [
+    "serviceAccount:terraform-deployer@${var.project_id}.iam.gserviceaccount.com",
+  ]
+}

--- a/service-account-iam-binding/outputs.tf
+++ b/service-account-iam-binding/outputs.tf
@@ -1,0 +1,9 @@
+output "service_account_email" {
+  description = "Email of the created service account"
+  value       = google_service_account.example.email
+}
+
+output "service_account_id" {
+  description = "ID of the created service account"
+  value       = google_service_account.example.id
+}

--- a/service-account-iam-binding/providers.tf
+++ b/service-account-iam-binding/providers.tf
@@ -1,0 +1,5 @@
+provider "google" {
+  project                     = var.project_id
+  region                      = var.region
+  impersonate_service_account = "terraform-deployer@${var.project_id}.iam.gserviceaccount.com"
+}

--- a/service-account-iam-binding/terraform.tfvars.example
+++ b/service-account-iam-binding/terraform.tfvars.example
@@ -1,0 +1,2 @@
+project_id = "your-gcp-project-id"
+region     = "us-central1"

--- a/service-account-iam-binding/variables.tf
+++ b/service-account-iam-binding/variables.tf
@@ -1,0 +1,10 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "us-central1"
+}

--- a/service-account-iam-binding/versions.tf
+++ b/service-account-iam-binding/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add Terraform configuration for Google Cloud service account and IAM bindings
- Create terraform-deployer service account with minimal custom role permissions  
- Implement service account impersonation for secure deployments
- Structure files properly with separation of concerns

## Changes
- **service-account-iam-binding/**: Main Terraform configuration
  - Creates example service account with IAM bindings
  - Configures service account impersonation
- **iam/**: Deployment service account setup
  - Creates terraform-deployer service account
  - Defines custom role with minimal required permissions
  - Sets up user access for service account impersonation

## Test plan
- [x] Terraform configurations validate successfully
- [x] Service accounts and IAM bindings deployed to GCP
- [x] Service account impersonation configured properly
- [x] Pre-commit hooks pass (formatting, linting)

🤖 Generated with [Claude Code](https://claude.ai/code)