### PR TITLE
fix: Add force_delete to ECR repository for easier cleanup

### DIFF
--- a/aurora-faiover/terraform/ecr.tf
+++ b/aurora-faiover/terraform/ecr.tf
@@ -2,6 +2,7 @@
 resource "aws_ecr_repository" "aurora_failover_app" {
   name                 = "${var.name_prefix}-typescript-app"
   image_tag_mutability = "MUTABLE"
+  force_delete         = true
 
   image_scanning_configuration {
     scan_on_push = true


### PR DESCRIPTION
## Summary
- Add `force_delete = true` to ECR repository configuration
- Allows terraform destroy to succeed even with remaining Docker images
- Improves infrastructure cleanup process for test environments

## Background
During the Aurora failover monitoring project cleanup, we encountered an issue where terraform destroy failed because the ECR repository contained Docker images. The ECR repository deletion would fail with:

```
Error: ECR Repository (aurora-failover-test-typescript-app) not empty, consider using force_delete
```

## Changes
- Added `force_delete = true` to the `aws_ecr_repository` resource in `terraform/ecr.tf`
- This allows Terraform to automatically delete all images before destroying the repository
- Simplifies cleanup process for development and test environments

## Test plan
- [x] Verified terraform destroy now succeeds even with Docker images present
- [x] Confirmed ECR repository and all images are properly cleaned up
- [x] Validated no infrastructure costs remain after destroy

🤖 Generated with [Claude Code](https://claude.ai/code)